### PR TITLE
Bump GitHub Actions to current majors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: "actions/setup-python@v5"
+        uses: "actions/setup-python@v7"
         with:
           python-version: "${{ matrix.python-version }}"
           allow-prereleases: true
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
 
       - name: Set up Python 3.12
-        uses: "actions/setup-python@v5"
+        uses: "actions/setup-python@v7"
         with:
           python-version: "3.12"
 
@@ -82,7 +82,7 @@ jobs:
           poetry run twine check dist/*
 
       - name: Upload build artifacts
-        uses: "actions/upload-artifact@v4"
+        uses: "actions/upload-artifact@v7"
         with:
           name: dist
           path: dist/ 

--- a/.github/workflows/decorator-check.yml
+++ b/.github/workflows/decorator-check.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: "actions/setup-python@v5"
+        uses: "actions/setup-python@v7"
         with:
           python-version: "3.12"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -37,11 +37,11 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install Poetry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       #if: github.event_name == 'release'
       - name: Checkout code
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
 
       - name: Set up Python 3.12
-        uses: "actions/setup-python@v5"
+        uses: "actions/setup-python@v7"
         with:
           python-version: "3.12"
 
@@ -41,7 +41,7 @@ jobs:
           poetry run twine check dist/*
 
       - name: Download build artifacts
-        uses: "actions/download-artifact@v4"
+        uses: "actions/download-artifact@v8"
         with:
           name: dist
           path: dist


### PR DESCRIPTION
Use actions/checkout@v7, setup-python@v7, upload-artifact@v7, and download-artifact@v8 across CI, docs, publish, and decorator workflows.